### PR TITLE
macOS bundling grammar correction

### DIFF
--- a/get/macos.md
+++ b/get/macos.md
@@ -1,6 +1,6 @@
 # Get curl for macOS
 
-macOS comes with the curl tool bundled with the operating system since many
+macOS comes with the curl tool bundled with the operating system for many
 years. If you want to upgrade to the latest version shipped by the curl
 project, we recommend installing [homebrew](https://brew.sh/) (a macOS
 software package manager) and then install the curl package from them:


### PR DESCRIPTION
Changed to "for", because "since" wasn't correct there.  

One source (https://daniel.haxx.se/blog/2021/09/25/curls-first-twenty-years-on-the-mac/#:~:text=years%20ago%20today.-,Mac%20OS%20X%2010.1,Apple%20that%20bundled%20curl,-.%20It%20was%20a) claims that Mac OS X 10.1, released on 25 September 2001, was the first version to include curl.  If that can be verified, then the sentence could instead be written as…

"macOS has included the curl tool since 25 September 2001."